### PR TITLE
Fix `assist control` option

### DIFF
--- a/custom_components/perplexity/config_flow.py
+++ b/custom_components/perplexity/config_flow.py
@@ -328,10 +328,7 @@ class PerplexityConversationFlowHandler(ConfigSubentryFlow):
             ): TemplateSelector(),
             vol.Optional(
                 CONF_LLM_HASS_API,
-                default=self.options.get(
-                    CONF_LLM_HASS_API,
-                    RECOMMENDED_CONVERSATION_OPTIONS[CONF_LLM_HASS_API],
-                ),
+                default=self.options.get(CONF_LLM_HASS_API, []),
             ): SelectSelector(SelectSelectorConfig(options=hass_apis, multiple=True)),
             vol.Required(
                 CONF_WEB_SEARCH,


### PR DESCRIPTION
Closes https://github.com/bieniu/ha-perplexity/issues/133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted the LLM API selection form to start with an empty selection instead of pre-selected defaults, giving users clearer control over their configuration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->